### PR TITLE
Apply scale_array from datapackages during matrix construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,14 @@ You may also find it useful to iterate through `MappedMatrix.groups`, which are 
 
 ### `ResourceGroup` class
 
-A `bw_processing` data package is essentially a metadata file and a bag of data resources. These resources are *grouped*, for multiple resources are needed to build one matrix, or one component of one matrix. For example, one needs not only the data vector, but also the row and column indices to build a simple matrix. One could also have a `flip` vector, in another file, used to flip the signs of data elements before matrix insertion.
+A `bw_processing` data package is essentially a metadata file and a bag of data resources. These resources are *grouped*, for multiple resources are needed to build one matrix, or one component of one matrix. For example, one needs not only the data vector, but also the row and column indices to build a simple matrix. One could also have a `flip` vector (to negate signs before insertion) or a `scale` vector (to apply a per-exchange multiplicative factor before insertion, e.g. for allocation or unit conversion).
 
 The `ResourceGroup` class provides a single interface to these data files and their metadata. `ResourceGroup` instances are created automatically by `MappedMatrix`, and available via `MappedMatrix.groups`. The [source code](https://github.com/brightway-lca/matrix_utils/) is pretty readable, and in general you probably don't need to worry about this low-level class, but the following could be useful:
 
 * `ResourceGroup.data_original`: The data as it is present in the datapackage, before masking (i.e. the Numpy data vector or array, or the data interface). This is the raw input data, duplicate elements are not aggregated (if applicable).
-* `ResourceGroup.data_current`: The data sample used (before aggregation) to build the matrix. It is both masked and flipped.
+* `ResourceGroup.data_current`: The data sample used (before aggregation) to build the matrix. It is masked, flipped (if a flip array is present), and scaled (if a scale array is present).
+* `ResourceGroup.has_scale`: Boolean property; `True` if the resource group includes a scale array.
+* `ResourceGroup.scale`: The scale array with all masks applied. Raises `KeyError` if no scale array is present; check `has_scale` first.
 * `ResourceGroup.row|col_mapped`: Mapped row and column indices. Has the same length as the datapackage resource, but uses `-1` for values which weren't mapped.
 * `ResourceGroup.row|col_masked`: The data after the custom filter and mapping mask have been applied.
 * `rResourceGroup.row|col_matrix`: Row and column indices (but not data) for insertion into the matrix. These indices are after aggregation within the resource group (if any).

--- a/README.md
+++ b/README.md
@@ -69,11 +69,10 @@ The `ResourceGroup` class provides a single interface to these data files and th
 
 * `ResourceGroup.data_original`: The data as it is present in the datapackage, before masking (i.e. the Numpy data vector or array, or the data interface). This is the raw input data, duplicate elements are not aggregated (if applicable).
 * `ResourceGroup.data_current`: The data sample used (before aggregation) to build the matrix. It is masked, flipped (if a flip array is present), and scaled (if a scale array is present).
-* `ResourceGroup.has_scale`: Boolean property; `True` if the resource group includes a scale array.
-* `ResourceGroup.scale`: The scale array with all masks applied. Raises `KeyError` if no scale array is present; check `has_scale` first.
+* `ResourceGroup.scale`: The scale array with all masks applied. Raises `KeyError` if no scale array is present.
 * `ResourceGroup.row|col_mapped`: Mapped row and column indices. Has the same length as the datapackage resource, but uses `-1` for values which weren't mapped.
 * `ResourceGroup.row|col_masked`: The data after the custom filter and mapping mask have been applied.
-* `rResourceGroup.row|col_matrix`: Row and column indices (but not data) for insertion into the matrix. These indices are after aggregation within the resource group (if any).
+* `ResourceGroup.row|col_matrix`: Row and column indices (but not data) for insertion into the matrix. These indices are after aggregation within the resource group (if any).
 * `ResourceGroup.calculate(vector=None)`: Function to recalculate matrix row, column, and data vectors. Uses the current state of the indexers, but re-draws values from data iterators. If `vector` is given, use this instead of the given data source.
 * `ResourceGroup.indexer`: The instance of the `Indexer` class applicable for this `ResourceGroup`. Only used for data arrays.
 * `ResourceGroup.ncols`: The integer number of columns in a data array. Returns `None` if a data vector is present.

--- a/matrix_utils/resource_group.py
+++ b/matrix_utils/resource_group.py
@@ -132,14 +132,6 @@ class ResourceGroup:
         return self.apply_masks(self.get_resource_by_suffix("flip"))
 
     @property
-    def has_scale(self):
-        try:
-            self.get_resource_by_suffix("scale")
-            return True
-        except KeyError:
-            return False
-
-    @property
     def scale(self):
         """The scale array, with all masks applied (if necessary)."""
         return self.apply_masks(self.get_resource_by_suffix("scale"))
@@ -312,8 +304,10 @@ class ResourceGroup:
             # No flip array
             pass
 
-        if self.has_scale:
+        try:
             data *= self.scale
+        except KeyError:
+            pass
 
         # Second copy because we want to store the data before aggregation
         self.data_current = data.copy()

--- a/matrix_utils/resource_group.py
+++ b/matrix_utils/resource_group.py
@@ -131,6 +131,19 @@ class ResourceGroup:
         """The flip array, with all masks applied (if necessary)."""
         return self.apply_masks(self.get_resource_by_suffix("flip"))
 
+    @property
+    def has_scale(self):
+        try:
+            self.get_resource_by_suffix("scale")
+            return True
+        except KeyError:
+            return False
+
+    @property
+    def scale(self):
+        """The scale array, with all masks applied (if necessary)."""
+        return self.apply_masks(self.get_resource_by_suffix("scale"))
+
     def get_indices_data(self):
         """The source data for the indices array."""
         indices = self.get_resource_by_suffix("indices")
@@ -298,6 +311,9 @@ class ResourceGroup:
         except KeyError:
             # No flip array
             pass
+
+        if self.has_scale:
+            data *= self.scale
 
         # Second copy because we want to store the data before aggregation
         self.data_current = data.copy()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "numpy",
     "scipy>=1.10",
     "pandas",
-    "bw_processing>=1.0",
+    "bw_processing>=1.3",
     "stats_arrays",
 ]
 

--- a/tests/resource_group.py
+++ b/tests/resource_group.py
@@ -166,16 +166,6 @@ def make_scaled_group(scale_array=None, flip_array=None):
     return g
 
 
-def test_has_scale_false():
-    g = make_scaled_group()
-    assert not g.has_scale
-
-
-def test_has_scale_true():
-    g = make_scaled_group(scale_array=np.array([0.5, 1.0, 2.0]))
-    assert g.has_scale
-
-
 def test_scale_applied_static():
     scale = np.array([0.5, 1.0, 2.0])
     g = make_scaled_group(scale_array=scale)
@@ -223,3 +213,31 @@ def test_scale_applied_array():
     next(g.indexer)
     g.calculate()
     assert np.allclose(g.data_current, [5.5, 21.0, 62.0])
+
+
+def test_scale_applied_vector_override():
+    scale = np.array([0.5, 1.0, 2.0])
+    g = make_scaled_group(scale_array=scale)
+    g.calculate(vector=np.array([4.0, 5.0, 6.0]))
+    assert np.allclose(g.data_current, [2.0, 5.0, 12.0])
+
+
+def test_scale_applied_masked():
+    scale = np.array([0.5, 1.0, 2.0])
+    dp = create_datapackage()
+    dp.add_persistent_vector(
+        matrix="foo",
+        name="s",
+        indices_array=np.array([(0, 1), (2, 3), (4, 5)], dtype=INDICES_DTYPE),
+        data_array=np.array([10.0, 20.0, 30.0]),
+        scale_array=scale,
+    )
+    g = ResourceGroup(package=dp.filter_by_attribute("group", "s"), group_label="s")
+    g.add_indexer(SequentialIndexer())
+    # Mappers that only cover the first two index pairs; (4, 5) will be masked out
+    g.add_mapper(0, ArrayMapper(array=np.array([0, 2]), empty_ok=True))
+    g.add_mapper(1, ArrayMapper(array=np.array([1, 3]), empty_ok=True))
+    g.map_indices()
+    g.calculate()
+    # Third element masked; [10, 20] * [0.5, 1.0] = [5, 20]
+    assert np.allclose(g.data_current, [5.0, 20.0])

--- a/tests/resource_group.py
+++ b/tests/resource_group.py
@@ -146,3 +146,80 @@ def test_row_col_indices_for_mapping_are_contiguous():
     assert g.col_indices_for_mapping().flags["C_CONTIGUOUS"]
     assert np.array_equal(g.unique_row_indices_for_mapping(), np.array([10, 20, 30]))
     assert np.array_equal(g.unique_col_indices_for_mapping(), np.array([14, 15, 16]))
+
+
+def make_scaled_group(scale_array=None, flip_array=None):
+    dp = create_datapackage()
+    kwargs = dict(
+        matrix="foo",
+        name="s",
+        indices_array=np.array([(0, 1), (2, 3), (4, 5)], dtype=INDICES_DTYPE),
+        data_array=np.array([10.0, 20.0, 30.0]),
+    )
+    if scale_array is not None:
+        kwargs["scale_array"] = scale_array
+    if flip_array is not None:
+        kwargs["flip_array"] = flip_array
+    dp.add_persistent_vector(**kwargs)
+    g = ResourceGroup(package=dp.filter_by_attribute("group", "s"), group_label="s")
+    complete_group(g)
+    return g
+
+
+def test_has_scale_false():
+    g = make_scaled_group()
+    assert not g.has_scale
+
+
+def test_has_scale_true():
+    g = make_scaled_group(scale_array=np.array([0.5, 1.0, 2.0]))
+    assert g.has_scale
+
+
+def test_scale_applied_static():
+    scale = np.array([0.5, 1.0, 2.0])
+    g = make_scaled_group(scale_array=scale)
+    g.calculate()
+    assert np.allclose(g.data_current, [5.0, 20.0, 60.0])
+
+
+def test_scale_applied_after_flip():
+    scale = np.array([0.5, 1.0, 2.0])
+    flip = np.array([True, False, False])
+    g = make_scaled_group(scale_array=scale, flip_array=flip)
+    g.calculate()
+    # flip negates first element, then scale is applied
+    assert np.allclose(g.data_current, [-5.0, 20.0, 60.0])
+
+
+def test_no_scale_unchanged():
+    g = make_scaled_group()
+    g.calculate()
+    assert np.allclose(g.data_current, [10.0, 20.0, 30.0])
+
+
+def test_scale_applied_array():
+    dp = create_datapackage(sequential=True)
+    # 3 exchanges, 4 columns (Monte Carlo samples)
+    data_array = np.array(
+        [[10.0, 11.0, 12.0, 13.0], [20.0, 21.0, 22.0, 23.0], [30.0, 31.0, 32.0, 33.0]]
+    )
+    scale_array = np.array([0.5, 1.0, 2.0])
+    dp.add_persistent_array(
+        matrix="foo",
+        name="s",
+        indices_array=np.array([(0, 1), (2, 3), (4, 5)], dtype=INDICES_DTYPE),
+        data_array=data_array,
+        scale_array=scale_array,
+    )
+    g = ResourceGroup(package=dp.filter_by_attribute("group", "s"), group_label="s")
+    complete_group(g)
+
+    # column 0: [10, 20, 30] * [0.5, 1.0, 2.0] = [5, 20, 60]
+    g.calculate()
+    assert np.allclose(g.data_current, [5.0, 20.0, 60.0])
+
+    # column 1: [11, 21, 31] * [0.5, 1.0, 2.0] = [5.5, 21, 62]
+    next(g.indexer)
+    g.calculate()
+    assert np.allclose(g.data_current, [5.5, 21.0, 62.0])


### PR DESCRIPTION
## Summary

Consumes the new `scale_array` resource (kind `"scale"`) introduced in [bw_processing #89](https://github.com/brightway-lca/bw_processing/pull/89).

- `ResourceGroup.has_scale` — boolean property, mirrors `has_distributions`
- `ResourceGroup.scale` — returns the scale array with all masks applied
- `ResourceGroup.calculate()` applies `data *= self.scale` after sign-flipping and before aggregation, for both static and stochastically-sampled values
- README updated: `flip` and `scale` described together in the ResourceGroup section; `data_current` description updated to reflect scaling; `has_scale` and `scale` properties documented

## Test plan

- [ ] `test_has_scale_false` — group without scale array reports `False`
- [ ] `test_has_scale_true` — group with scale array reports `True`
- [ ] `test_scale_applied_static` — vector data multiplied correctly
- [ ] `test_scale_applied_after_flip` — scale applied after flip (sign resolved first)
- [ ] `test_no_scale_unchanged` — absence of scale array leaves data untouched
- [ ] `test_scale_applied_array` — array (presample) data scaled correctly across two sequential columns

## Depends on

bw_processing #89 must be merged and released before this can be merged.