### PR TITLE
Fix CI not running on subsequent PR commits

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -17,7 +17,7 @@ on:
       - ".gitignore"
   pull_request:
     branches: [main, develop]
-    types: [opened, reopened] # excludes syncronize to avoid redundant trigger from commits on PRs
+    types: [opened, reopened, synchronize]
     paths-ignore:
       - "**.md"
       - "**.bib"


### PR DESCRIPTION
## Summary

- The `pull_request` trigger had `types: [opened, reopened]`, which explicitly excluded the `synchronize` event
- `synchronize` fires when new commits are pushed to an open PR branch — without it, CI only ran when a PR was first opened or reopened
- Added `synchronize` to the event types list to fix this

## Test plan

- [ ] Open a PR and confirm CI runs on open
- [ ] Push a follow-up commit to that PR and confirm CI runs again