### PR TITLE
Improve access to indexer values

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Out[3]:
 
 `MappedMatrix` is iterable; calling `next()` will draw new samples from all included stochastic resources, and rebuild the matrix.
 
+#### Indexers
+
+Each datapackage is assigned exactly one indexer, shared across all its resource groups. This indexer determines which column of an array resource is used on each iteration. The design assumption is one indexer per datapackage — `MappedMatrix.indexers` returns a `{name: indexer}` dict at that level. `MappedMatrix.local_indexers` returns a `{group_label: indexer}` dict for what each resource group is actually using, which will normally be the same object (or a `Proxy` wrapping it for combinatorial packages). You may replace `group.indexer` on any individual group after construction, but you are then responsible for the consequences — in particular, `next()` only advances the package-level indexers, so any custom group-level indexer must be advanced manually.
+
 You may also find it useful to iterate through `MappedMatrix.groups`, which are instances of `ResourceGroup`, documented below.
 
 ### `ResourceGroup` class
@@ -74,7 +78,7 @@ The `ResourceGroup` class provides a single interface to these data files and th
 * `ResourceGroup.row|col_masked`: The data after the custom filter and mapping mask have been applied.
 * `ResourceGroup.row|col_matrix`: Row and column indices (but not data) for insertion into the matrix. These indices are after aggregation within the resource group (if any).
 * `ResourceGroup.calculate(vector=None)`: Function to recalculate matrix row, column, and data vectors. Uses the current state of the indexers, but re-draws values from data iterators. If `vector` is given, use this instead of the given data source.
-* `ResourceGroup.indexer`: The instance of the `Indexer` class applicable for this `ResourceGroup`. Only used for data arrays.
+* `ResourceGroup.indexer`: The instance of the `Indexer` class applicable for this `ResourceGroup`. Only used for data arrays. By design each datapackage has one indexer shared across all its resource groups; this is set up automatically by `MappedMatrix`. You may assign a different indexer to individual groups after construction, but you are then responsible for keeping them consistent (e.g. ensuring they advance together when `next()` is called).
 * `ResourceGroup.ncols`: The integer number of columns in a data array. Returns `None` if a data vector is present.
 
 ## Contributing

--- a/matrix_utils/mapped_matrix.py
+++ b/matrix_utils/mapped_matrix.py
@@ -257,8 +257,14 @@ class MappedMatrix:
                     obj.add_indexer(indexer=package.indexer)
 
     @property
-    def global_indexers(self) -> dict:
-        """Return package-level indexers keyed by datapackage name."""
+    def indexers(self) -> dict:
+        """Return package-level indexers keyed by datapackage name.
+
+        By design each datapackage has one indexer shared across all its resource groups,
+        but this constraint is not enforced — individual groups can be given different
+        indexers after construction. Use ``local_indexers`` to inspect what each group
+        is actually using.
+        """
         return {
             package.metadata["name"]: package.indexer
             for package in self.packages
@@ -267,21 +273,22 @@ class MappedMatrix:
 
     @property
     def local_indexers(self) -> dict:
-        """Return resource group indexers keyed by group label."""
+        """Return the indexer actually used by each resource group, keyed by group label.
+
+        Normally all groups within a package share the same indexer (or a ``Proxy``
+        wrapping it for combinatorial packages), but users can assign a different indexer
+        to any group after construction, so this may differ from ``indexers``.
+        """
         return {group.label: group.indexer for group in self.groups if hasattr(group, "indexer")}
 
     def indexers_by_type(self, indexer_type: type) -> list:
-        """Return all global indexers that are instances of ``indexer_type``."""
-        return [
-            indexer
-            for indexer in self.global_indexers.values()
-            if isinstance(indexer, indexer_type)
-        ]
+        """Return all package-level indexers that are instances of ``indexer_type``."""
+        return [indexer for indexer in self.indexers.values() if isinstance(indexer, indexer_type)]
 
     @property
-    def global_indexers_are_unique(self) -> bool:
+    def indexers_are_unique(self) -> bool:
         """True if no two packages share the same indexer instance."""
-        indexers = list(self.global_indexers.values())
+        indexers = list(self.indexers.values())
         return len({id(i) for i in indexers}) == len(indexers)
 
     def input_data_vector(self) -> np.ndarray:

--- a/matrix_utils/mapped_matrix.py
+++ b/matrix_utils/mapped_matrix.py
@@ -256,6 +256,34 @@ class MappedMatrix:
                 for obj in resources:
                     obj.add_indexer(indexer=package.indexer)
 
+    @property
+    def global_indexers(self) -> dict:
+        """Return package-level indexers keyed by datapackage name."""
+        return {
+            package.metadata["name"]: package.indexer
+            for package in self.packages
+            if hasattr(package, "indexer")
+        }
+
+    @property
+    def local_indexers(self) -> dict:
+        """Return resource group indexers keyed by group label."""
+        return {group.label: group.indexer for group in self.groups if hasattr(group, "indexer")}
+
+    def indexers_by_type(self, indexer_type: type) -> list:
+        """Return all global indexers that are instances of ``indexer_type``."""
+        return [
+            indexer
+            for indexer in self.global_indexers.values()
+            if isinstance(indexer, indexer_type)
+        ]
+
+    @property
+    def global_indexers_are_unique(self) -> bool:
+        """True if no two packages share the same indexer instance."""
+        indexers = list(self.global_indexers.values())
+        return len({id(i) for i in indexers}) == len(indexers)
+
     def input_data_vector(self) -> np.ndarray:
         return np.hstack([group.data_current for group in self.groups])
 

--- a/tests/mapped_matrix.py
+++ b/tests/mapped_matrix.py
@@ -870,23 +870,23 @@ def test_input_indexer_vector_raises_on_unsupported_type():
         mm.input_indexer_vector()
 
 
-def test_global_indexers_single_package():
+def test_indexers_single_package():
     from matrix_utils.indexers import RandomIndexer
 
     dp = basic_mm(name="alpha")
     mm = MappedMatrix(packages=[dp], matrix="foo", use_arrays=False, use_distributions=False)
-    gi = mm.global_indexers
+    gi = mm.indexers
     assert list(gi.keys()) == ["alpha"]
     assert isinstance(gi["alpha"], RandomIndexer)
 
 
-def test_global_indexers_multiple_packages():
+def test_indexers_multiple_packages():
     from matrix_utils.indexers import RandomIndexer
 
     dp1 = basic_mm(name="pkg-one")
     dp2 = basic_mm(name="pkg-two")
     mm = MappedMatrix(packages=[dp1, dp2], matrix="foo", use_arrays=False, use_distributions=False)
-    gi = mm.global_indexers
+    gi = mm.indexers
     assert set(gi.keys()) == {"pkg-one", "pkg-two"}
     assert isinstance(gi["pkg-one"], RandomIndexer)
     assert isinstance(gi["pkg-two"], RandomIndexer)
@@ -924,7 +924,7 @@ def test_local_indexers_combinatorial_are_proxies():
     assert set(li.keys()) == {"g", "h"}
     assert all(isinstance(v, Proxy) for v in li.values())
     # global indexer is the underlying CombinatorialIndexer
-    assert isinstance(mm.global_indexers["combo"], CombinatorialIndexer)
+    assert isinstance(mm.indexers["combo"], CombinatorialIndexer)
 
 
 def test_indexers_by_type():
@@ -950,14 +950,14 @@ def test_indexers_by_type():
     assert isinstance(seq_indexers[0], SequentialIndexer)
 
 
-def test_global_indexers_are_unique_true():
+def test_indexers_are_unique_true():
     dp1 = basic_mm(name="a")
     dp2 = basic_mm(name="b")
     mm = MappedMatrix(packages=[dp1, dp2], matrix="foo", use_arrays=False, use_distributions=False)
-    assert mm.global_indexers_are_unique is True
+    assert mm.indexers_are_unique is True
 
 
-def test_global_indexers_are_unique_false_with_override():
+def test_indexers_are_unique_false_with_override():
     from matrix_utils.indexers import SequentialIndexer
 
     shared = SequentialIndexer()
@@ -970,4 +970,4 @@ def test_global_indexers_are_unique_false_with_override():
         use_distributions=False,
         indexer_override=shared,
     )
-    assert mm.global_indexers_are_unique is False
+    assert mm.indexers_are_unique is False

--- a/tests/mapped_matrix.py
+++ b/tests/mapped_matrix.py
@@ -868,3 +868,106 @@ def test_input_indexer_vector_raises_on_unsupported_type():
 
     with pytest.raises(ValueError, match="Can't understand indexer value"):
         mm.input_indexer_vector()
+
+
+def test_global_indexers_single_package():
+    from matrix_utils.indexers import RandomIndexer
+
+    dp = basic_mm(name="alpha")
+    mm = MappedMatrix(packages=[dp], matrix="foo", use_arrays=False, use_distributions=False)
+    gi = mm.global_indexers
+    assert list(gi.keys()) == ["alpha"]
+    assert isinstance(gi["alpha"], RandomIndexer)
+
+
+def test_global_indexers_multiple_packages():
+    from matrix_utils.indexers import RandomIndexer
+
+    dp1 = basic_mm(name="pkg-one")
+    dp2 = basic_mm(name="pkg-two")
+    mm = MappedMatrix(packages=[dp1, dp2], matrix="foo", use_arrays=False, use_distributions=False)
+    gi = mm.global_indexers
+    assert set(gi.keys()) == {"pkg-one", "pkg-two"}
+    assert isinstance(gi["pkg-one"], RandomIndexer)
+    assert isinstance(gi["pkg-two"], RandomIndexer)
+    # each package gets its own indexer instance
+    assert gi["pkg-one"] is not gi["pkg-two"]
+
+
+def test_local_indexers_keyed_by_group_label():
+    from matrix_utils.indexers import RandomIndexer
+
+    dp = basic_mm(name="alpha")
+    mm = MappedMatrix(packages=[dp], matrix="foo", use_arrays=False, use_distributions=False)
+    li = mm.local_indexers
+    # basic_mm adds two vector groups: "vector" and "vector2"
+    assert set(li.keys()) == {"vector", "vector2"}
+    # both groups share the same package-level indexer instance
+    assert isinstance(li["vector"], RandomIndexer)
+    assert li["vector"] is li["vector2"]
+
+
+def test_local_indexers_combinatorial_are_proxies():
+    from matrix_utils.indexers import CombinatorialIndexer, Proxy
+
+    dp = bwp.create_datapackage(combinatorial=True, name="combo")
+    indices = np.array([(0, 0), (1, 1)], dtype=bwp.INDICES_DTYPE)
+    dp.add_persistent_array(
+        matrix="foo", name="g", indices_array=indices, data_array=np.array([[1, 2], [3, 4]]).T
+    )
+    dp.add_persistent_array(
+        matrix="foo", name="h", indices_array=indices, data_array=np.array([[5, 6], [7, 8]]).T
+    )
+
+    mm = MappedMatrix(packages=[dp], matrix="foo")
+    li = mm.local_indexers
+    assert set(li.keys()) == {"g", "h"}
+    assert all(isinstance(v, Proxy) for v in li.values())
+    # global indexer is the underlying CombinatorialIndexer
+    assert isinstance(mm.global_indexers["combo"], CombinatorialIndexer)
+
+
+def test_indexers_by_type():
+    from matrix_utils.indexers import RandomIndexer, SequentialIndexer
+
+    dp_rand = basic_mm(name="rand")
+    dp_seq = bwp.create_datapackage(sequential=True, name="seq")
+    dp_seq.add_persistent_vector(
+        matrix="foo",
+        name="v",
+        indices_array=np.array([(0, 0)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([1.0]),
+    )
+    mm = MappedMatrix(
+        packages=[dp_rand, dp_seq], matrix="foo", use_arrays=False, use_distributions=False
+    )
+
+    rand_indexers = mm.indexers_by_type(RandomIndexer)
+    seq_indexers = mm.indexers_by_type(SequentialIndexer)
+    assert len(rand_indexers) == 1
+    assert isinstance(rand_indexers[0], RandomIndexer)
+    assert len(seq_indexers) == 1
+    assert isinstance(seq_indexers[0], SequentialIndexer)
+
+
+def test_global_indexers_are_unique_true():
+    dp1 = basic_mm(name="a")
+    dp2 = basic_mm(name="b")
+    mm = MappedMatrix(packages=[dp1, dp2], matrix="foo", use_arrays=False, use_distributions=False)
+    assert mm.global_indexers_are_unique is True
+
+
+def test_global_indexers_are_unique_false_with_override():
+    from matrix_utils.indexers import SequentialIndexer
+
+    shared = SequentialIndexer()
+    dp1 = basic_mm(name="a")
+    dp2 = basic_mm(name="b")
+    mm = MappedMatrix(
+        packages=[dp1, dp2],
+        matrix="foo",
+        use_arrays=False,
+        use_distributions=False,
+        indexer_override=shared,
+    )
+    assert mm.global_indexers_are_unique is False


### PR DESCRIPTION
## Summary

Closes #20.

Adds four new members to `MappedMatrix` for inspecting indexers at both the package and resource-group level:

- `indexers` — `dict[str, Indexer]` mapping datapackage name to its package-level indexer
- `local_indexers` — `dict[str, Indexer]` mapping resource group label to its indexer (returns `Proxy` objects for combinatorial packages)
- `indexers_by_type(t)` — returns a list of package-level indexers that are instances of the given class
- `indexers_are_unique` — `True` if no two packages share the same indexer instance (useful for detecting `indexer_override` usage)

By design each datapackage has one indexer shared across all its resource groups, but this is not enforced. Users may assign different indexers to individual groups after construction; `local_indexers` reflects what each group is actually using. See the README for details.

## Test plan

- [ ] `test_indexers_single_package` — key and type correct for one package
- [ ] `test_indexers_multiple_packages` — both keys present, instances are distinct
- [ ] `test_local_indexers_keyed_by_group_label` — both group labels present, groups share the same instance
- [ ] `test_local_indexers_combinatorial_are_proxies` — combinatorial groups expose `Proxy` locally, `CombinatorialIndexer` via `indexers`
- [ ] `test_indexers_by_type` — correctly filters `RandomIndexer` vs `SequentialIndexer`
- [ ] `test_indexers_are_unique_true` — two independent packages → `True`
- [ ] `test_indexers_are_unique_false_with_override` — shared `indexer_override` → `False`