### PR TITLE
NaN in data vectors/arrays skips matrix insertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Out[3]:
 
 Each datapackage is assigned exactly one indexer, shared across all its resource groups. This indexer determines which column of an array resource is used on each iteration. The design assumption is one indexer per datapackage — `MappedMatrix.indexers` returns a `{name: indexer}` dict at that level. `MappedMatrix.local_indexers` returns a `{group_label: indexer}` dict for what each resource group is actually using, which will normally be the same object (or a `Proxy` wrapping it for combinatorial packages). You may replace `group.indexer` on any individual group after construction, but you are then responsible for the consequences — in particular, `next()` only advances the package-level indexers, so any custom group-level indexer must be advanced manually.
 
+#### NaN as a sentinel value
+
+A `NaN` value in a data vector or array is treated as **"no data insertion"** — that element is skipped when the matrix is built or rebuilt, leaving the matrix cell at its current value. This is useful for scenario or override packages: place `NaN` at positions you want to inherit from an earlier package, and a real number where you want to override. Non-NaN elements behave normally. `ResourceGroup.data_current` still carries the raw `NaN` so `input_data_vector()` reflects the actual datapackage contents.
+
 You may also find it useful to iterate through `MappedMatrix.groups`, which are instances of `ResourceGroup`, documented below.
 
 ### `ResourceGroup` class

--- a/matrix_utils/mapped_matrix.py
+++ b/matrix_utils/mapped_matrix.py
@@ -219,6 +219,10 @@ class MappedMatrix:
         self.matrix.data *= 0
         for group in self.groups:
             row, col, data = group.calculate()
+            # NaN means "no data insertion" — skip those elements so earlier
+            # packages' values are preserved rather than overwritten with NaN.
+            nan_mask = ~np.isnan(data)
+            row, col, data = row[nan_mask], col[nan_mask], data[nan_mask]
             if group.package.metadata["sum_inter_duplicates"]:
                 self.matrix[row, col] += data
             else:

--- a/tests/mapped_matrix.py
+++ b/tests/mapped_matrix.py
@@ -1158,3 +1158,61 @@ def test_input_flip_vector_with_flip():
     assert flip.dtype == bool
     assert flip.sum() == 1
     assert len(flip) == len(mm.input_data_vector())
+
+
+def test_nan_in_vector_skips_insertion():
+    dp = bwp.create_datapackage()
+    dp.add_persistent_vector(
+        matrix="foo",
+        name="v",
+        indices_array=np.array([(0, 0), (1, 1), (2, 2)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([1.0, np.nan, 3.0]),
+    )
+    mm = MappedMatrix(packages=[dp], matrix="foo", use_arrays=False, use_distributions=False)
+    assert mm.matrix[0, 0] == 1.0
+    assert mm.matrix[1, 1] == 0.0  # NaN skipped, stays zero
+    assert mm.matrix[2, 2] == 3.0
+    assert not np.isnan(mm.matrix.data).any()
+
+
+def test_nan_in_array_skips_insertion():
+    dp = bwp.create_datapackage(sequential=True)
+    dp.add_persistent_array(
+        matrix="foo",
+        name="a",
+        indices_array=np.array([(0, 0), (1, 1)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([[1.0, np.nan], [3.0, 4.0]]),
+    )
+    mm = MappedMatrix(packages=[dp], matrix="foo", use_distributions=False)
+    # column 0: data = [1.0, 3.0] — both inserted
+    assert mm.matrix[0, 0] == 1.0
+    assert mm.matrix[1, 1] == 3.0
+    next(mm)
+    # column 1: data = [nan, 4.0] — first element skipped, stays zero
+    assert mm.matrix[0, 0] == 0.0
+    assert mm.matrix[1, 1] == 4.0
+    assert not np.isnan(mm.matrix.data).any()
+
+
+def test_nan_preserves_earlier_package_value():
+    # Package A sets values; package B uses NaN to leave them untouched.
+    dp_base = bwp.create_datapackage()
+    dp_base.add_persistent_vector(
+        matrix="foo",
+        name="base",
+        indices_array=np.array([(0, 0), (1, 1)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([5.0, 7.0]),
+    )
+    dp_scenario = bwp.create_datapackage()
+    dp_scenario.add_persistent_vector(
+        matrix="foo",
+        name="scenario",
+        indices_array=np.array([(0, 0), (1, 1)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([np.nan, 99.0]),
+    )
+    mm = MappedMatrix(
+        packages=[dp_base, dp_scenario], matrix="foo", use_arrays=False, use_distributions=False
+    )
+    assert mm.matrix[0, 0] == 5.0  # NaN in scenario → base value preserved
+    assert mm.matrix[1, 1] == 99.0  # non-NaN in scenario → overrides base
+    assert not np.isnan(mm.matrix.data).any()


### PR DESCRIPTION
## Summary

Closes #21.

A `NaN` value in a data vector or array now means **"don't insert anything here"** — that element is silently skipped during matrix construction and rebuilds. This makes `NaN` useful as a sentinel for scenario/override packages: a package can set some matrix elements to `NaN` to leave the values written by an earlier package untouched, rather than overwriting them with `NaN`.

The change is confined to `rebuild_matrix` — a `nan_mask` is applied to `row`, `col`, and `data` before the CSR assignment. `ResourceGroup.data_current` still carries the raw `NaN` so `input_data_vector()` remains honest about what the datapackage actually contains.

## Test plan

- [ ] `test_nan_in_vector_skips_insertion` — NaN element stays zero in the matrix, no NaN propagates into stored data
- [ ] `test_nan_in_array_skips_insertion` — same for array resources across iterations
- [ ] `test_nan_preserves_earlier_package_value` — NaN in a second package leaves the first package's value intact; non-NaN in the same package still overrides correctly