### PR TITLE
Widen flaky bounds in test_distributions_without_uncertainties

### DIFF
--- a/tests/monte_carlo.py
+++ b/tests/monte_carlo.py
@@ -111,8 +111,8 @@ def test_distributions_without_uncertainties():
     row = mm.row_mapper.to_dict()
     col = mm.col_mapper.to_dict()
 
-    assert 50 <= np.mean(results[row[10], col[20], :]) <= 150
-    assert 8 <= np.mean(results[row[11], col[21], :]) <= 14
+    assert 20 <= np.mean(results[row[10], col[20], :]) <= 180
+    assert 5 <= np.mean(results[row[11], col[21], :]) <= 18
 
     assert np.allclose(results[row[10], col[10], :], 11)
     assert np.allclose(results[row[18], col[7], :], 125)


### PR DESCRIPTION
## Summary

Fixes intermittent CI failures in `test_distributions_without_uncertainties`.

Lines 114–115 asserted sample means within ~2.8 standard errors of the theoretical means for only 10 samples, giving a ~0.6% chance of failure per run — enough to fail regularly across many CI jobs.

| Line | Distribution | Theoretical mean | Old bounds | Std errors | New bounds | Std errors |
|------|-------------|-----------------|-----------|-----------|-----------|-----------|
| 114 | Uniform(0, 200) | 100 | [50, 150] | ±2.7 | [20, 180] | ±4.4 |
| 115 | Triangular(0, 20, 15) | 11.67 | [8, 14] | ±2.8 | [5, 18] | ±4.9 |

The new bounds are wide enough to still catch a completely wrong distribution while making flakiness negligible.