### PR TITLE
Fix input_uncertainties crash when array group has no flip array

### DIFF
--- a/matrix_utils/mapped_matrix.py
+++ b/matrix_utils/mapped_matrix.py
@@ -453,7 +453,8 @@ class MappedMatrix:
 
                 array = self._construct_distributions_array(group.data_current, uncertainty_type=98)
                 array["loc"] = np.mean(data, axis=1)
-                array["loc"][group.flip] *= -1
+                if group.has_flip:
+                    array["loc"][group.flip] *= -1
                 array["scale"] = np.std(data, axis=1)
                 arrays.append(array)
             elif group.is_interface():

--- a/tests/mapped_matrix.py
+++ b/tests/mapped_matrix.py
@@ -708,6 +708,29 @@ def test_input_uncertainties_no_distributions(sensitivity_dps):
         assert np.allclose(ua[field], expected[field], equal_nan=True)
 
 
+def test_input_uncertainties_array_group_without_flip():
+    """Regression test for issue #8: array group without flip should not crash."""
+    dp = bwp.create_datapackage()
+    indices_array = np.array([(10, 10), (11, 11)], dtype=bwp.INDICES_DTYPE)
+    data_array = np.array([[7, 8], [8, 9], [9, 10]]).T
+    dp.add_persistent_array(
+        matrix="matrix",
+        data_array=data_array,
+        name="no_flip",
+        indices_array=indices_array,
+    )
+    mm = MappedMatrix(
+        packages=[dp],
+        matrix="matrix",
+        use_vectors=True,
+        use_arrays=True,
+        use_distributions=False,
+    )
+    ua = mm.input_uncertainties()
+    assert ua.shape == (2,)
+    assert np.allclose(ua["loc"], [8.0, 9.0])
+
+
 def test_input_index_vector(sensitivity_dps):
     dp = bwp.create_datapackage(combinatorial=True)
 


### PR DESCRIPTION
## Summary

- `MappedMatrix.input_uncertainties` unconditionally accessed `group.flip` inside the `is_array()` branch, raising a `KeyError` for any array resource group that doesn't include a flip array (fixes #8)
- Added a `group.has_flip` guard, matching the pattern already used in `input_flip_vector`
- Added regression test `test_input_uncertainties_array_group_without_flip`

## Test plan

- [ ] `pytest tests/mapped_matrix.py::test_input_uncertainties_array_group_without_flip` — new regression test passes
- [ ] `pytest tests/mapped_matrix.py -k input_uncertainties` — all existing `input_uncertainties` tests continue to pass