### PR TITLE
Add params_array support (bw_processing PR #93)

### DIFF
--- a/matrix_utils/mapped_matrix.py
+++ b/matrix_utils/mapped_matrix.py
@@ -397,6 +397,20 @@ class MappedMatrix:
                 position += num_elements
         return result
 
+    def input_params(self) -> dict:
+        """Return current parameter values keyed by group label.
+
+        Only groups that carry a params array are included; groups without
+        params are omitted entirely (not present vs. ``None``-valued).
+
+        For vector groups the full 1-D params array is returned (parameters
+        are fixed and do not vary by iteration). For array groups the column
+        matching the current indexer position is returned, so the result
+        stays in sync with ``input_data_vector`` across Monte Carlo
+        iterations.
+        """
+        return {group.label: group.params_current for group in self.groups if group.has_params}
+
     def input_indexer_vector(self) -> np.ndarray:
         index_values = []
 

--- a/matrix_utils/mapped_matrix.py
+++ b/matrix_utils/mapped_matrix.py
@@ -398,10 +398,12 @@ class MappedMatrix:
         return result
 
     def input_params(self) -> dict:
-        """Return current parameter values keyed by group label.
+        """Return current parameter values keyed by ``(package, group_label)``.
 
         Only groups that carry a params array are included; groups without
         params are omitted entirely (not present vs. ``None``-valued).
+        Keying by ``(package, group_label)`` avoids silent collisions when
+        two packages contribute groups with the same label.
 
         For vector groups the full 1-D params array is returned (parameters
         are fixed and do not vary by iteration). For array groups the column
@@ -409,7 +411,14 @@ class MappedMatrix:
         stays in sync with ``input_data_vector`` across Monte Carlo
         iterations.
         """
-        return {group.label: group.params_current for group in self.groups if group.has_params}
+        result = {}
+        for package, groups in self.packages.items():
+            for group in groups:
+                try:
+                    result[(package, group.label)] = group.params_current
+                except KeyError:
+                    pass
+        return result
 
     def input_indexer_vector(self) -> np.ndarray:
         index_values = []

--- a/matrix_utils/resource_group.py
+++ b/matrix_utils/resource_group.py
@@ -136,6 +136,48 @@ class ResourceGroup:
             return False
 
     @property
+    def has_params(self) -> bool:
+        try:
+            self.get_resource_by_suffix("params")
+            return True
+        except KeyError:
+            return False
+
+    @property
+    def has_param_labels(self) -> bool:
+        try:
+            self.get_resource_by_suffix("param_labels")
+            return True
+        except KeyError:
+            return False
+
+    @property
+    def params_current(self) -> np.ndarray:
+        """Current parameter values.
+
+        For vectors: returns the full 1-D params array (parameters are fixed
+        and do not vary by indexer position).
+        For arrays: returns the column at the current indexer position,
+        mirroring how ``calculate()`` picks the active data column.
+
+        Raises ``KeyError`` if no params array exists for this group.
+        """
+        data = self.get_resource_by_suffix("params")
+        if self.vector:
+            return data
+        return data[:, self.indexer.index % data.shape[1]]
+
+    @property
+    def param_labels(self) -> dict:
+        """Raw param-labels dict ``{"values": [...], "schema": {...}}``.
+
+        Raises ``KeyError`` if no param_labels resource exists.
+        To reconstruct a typed schema object call
+        ``bw_processing.param_labels.schema_from_json_schema(group.param_labels["schema"])``.
+        """
+        return self.get_resource_by_suffix("param_labels")
+
+    @property
     def n_elements_dropped(self) -> int:
         """Number of original datapackage elements dropped by the custom filter and mapping mask."""
         return len(self.get_indices_data()) - len(self.row_masked)

--- a/matrix_utils/resource_group.py
+++ b/matrix_utils/resource_group.py
@@ -169,11 +169,10 @@ class ResourceGroup:
 
     @property
     def param_labels(self) -> dict:
-        """Raw param-labels dict ``{"values": [...], "schema": {...}}``.
+        """Raw param-labels dict. Always has ``"values"``;
+        also has ``"schema"`` when a label schema was provided at write time.
 
         Raises ``KeyError`` if no param_labels resource exists.
-        To reconstruct a typed schema object call
-        ``bw_processing.param_labels.schema_from_json_schema(group.param_labels["schema"])``.
         """
         return self.get_resource_by_suffix("param_labels")
 

--- a/tests/mapped_matrix.py
+++ b/tests/mapped_matrix.py
@@ -9,6 +9,80 @@ from fsspec.implementations.zip import ZipFileSystem
 from matrix_utils import ArrayMapper, MappedMatrix
 from matrix_utils.errors import AllArraysEmpty, EmptyArray
 
+# --- input_params ---
+
+
+def _mm_with_params(**kwargs):
+    """Build a MappedMatrix from the given datapackages."""
+    return MappedMatrix(
+        matrix="foo",
+        use_vectors=True,
+        use_arrays=True,
+        use_distributions=False,
+        **kwargs,
+    )
+
+
+def test_input_params_empty_when_no_params():
+    mm = _mm_with_params(packages=[basic_mm()])
+    assert mm.input_params() == {}
+
+
+def test_input_params_vector():
+    dp = bwp.create_datapackage()
+    params = np.array([0.1, 0.9])
+    dp.add_persistent_vector(
+        matrix="foo",
+        name="v",
+        indices_array=np.array([(0, 0), (1, 1)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([5.0, 7.0]),
+        params_array=params,
+    )
+    mm = _mm_with_params(packages=[dp])
+    result = mm.input_params()
+    assert list(result.keys()) == ["v"]
+    assert np.allclose(result["v"], params)
+
+
+def test_input_params_only_groups_with_params_included():
+    dp = bwp.create_datapackage()
+    dp.add_persistent_vector(
+        matrix="foo",
+        name="with_params",
+        indices_array=np.array([(0, 0)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([1.0]),
+        params_array=np.array([42.0]),
+    )
+    dp.add_persistent_vector(
+        matrix="foo",
+        name="no_params",
+        indices_array=np.array([(1, 1)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([2.0]),
+    )
+    mm = _mm_with_params(packages=[dp])
+    result = mm.input_params()
+    assert set(result.keys()) == {"with_params"}
+
+
+def test_input_params_array_tracks_indexer():
+    dp = bwp.create_datapackage(sequential=True)
+    data = np.array([[10.0, 11.0, 12.0], [20.0, 21.0, 22.0]])
+    params = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    dp.add_persistent_array(
+        matrix="foo",
+        name="a",
+        indices_array=np.array([(0, 0), (1, 1)], dtype=bwp.INDICES_DTYPE),
+        data_array=data,
+        params_array=params,
+    )
+    mm = _mm_with_params(packages=[dp])
+    assert np.allclose(mm.input_params()["a"], [1.0, 4.0])
+    next(mm)
+    assert np.allclose(mm.input_params()["a"], [2.0, 5.0])
+    next(mm)
+    assert np.allclose(mm.input_params()["a"], [3.0, 6.0])
+
+
 dirpath = Path(__file__).parent.resolve() / "fixtures"
 
 

--- a/tests/mapped_matrix.py
+++ b/tests/mapped_matrix.py
@@ -40,8 +40,9 @@ def test_input_params_vector():
     )
     mm = _mm_with_params(packages=[dp])
     result = mm.input_params()
-    assert list(result.keys()) == ["v"]
-    assert np.allclose(result["v"], params)
+    pkg = list(mm.packages.keys())[0]
+    assert list(result.keys()) == [(pkg, "v")]
+    assert np.allclose(result[(pkg, "v")], params)
 
 
 def test_input_params_only_groups_with_params_included():
@@ -61,7 +62,8 @@ def test_input_params_only_groups_with_params_included():
     )
     mm = _mm_with_params(packages=[dp])
     result = mm.input_params()
-    assert set(result.keys()) == {"with_params"}
+    labels = {label for (_, label) in result}
+    assert labels == {"with_params"}
 
 
 def test_input_params_array_tracks_indexer():
@@ -76,11 +78,37 @@ def test_input_params_array_tracks_indexer():
         params_array=params,
     )
     mm = _mm_with_params(packages=[dp])
-    assert np.allclose(mm.input_params()["a"], [1.0, 4.0])
+    pkg = list(mm.packages.keys())[0]
+    assert np.allclose(mm.input_params()[(pkg, "a")], [1.0, 4.0])
     next(mm)
-    assert np.allclose(mm.input_params()["a"], [2.0, 5.0])
+    assert np.allclose(mm.input_params()[(pkg, "a")], [2.0, 5.0])
     next(mm)
-    assert np.allclose(mm.input_params()["a"], [3.0, 6.0])
+    assert np.allclose(mm.input_params()[(pkg, "a")], [3.0, 6.0])
+
+
+def test_input_params_duplicate_labels_across_packages():
+    dp1 = bwp.create_datapackage()
+    dp1.add_persistent_vector(
+        matrix="foo",
+        name="v",
+        indices_array=np.array([(0, 0)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([1.0]),
+        params_array=np.array([0.1]),
+    )
+    dp2 = bwp.create_datapackage()
+    dp2.add_persistent_vector(
+        matrix="foo",
+        name="v",
+        indices_array=np.array([(1, 1)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([2.0]),
+        params_array=np.array([0.9]),
+    )
+    mm = _mm_with_params(packages=[dp1, dp2])
+    result = mm.input_params()
+    assert len(result) == 2
+    values = list(result.values())
+    assert any(np.allclose(v, [0.1]) for v in values)
+    assert any(np.allclose(v, [0.9]) for v in values)
 
 
 dirpath = Path(__file__).parent.resolve() / "fixtures"

--- a/tests/resource_group.py
+++ b/tests/resource_group.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from bw_processing import INDICES_DTYPE, create_datapackage, load_datapackage
+from bw_processing import INDICES_DTYPE, StringLabelSchema, create_datapackage, load_datapackage
 from fsspec.implementations.zip import ZipFileSystem
 
 from matrix_utils import ArrayMapper, ResourceGroup
@@ -247,7 +247,7 @@ def test_rescale_applied_masked():
 # --- params support ---
 
 
-def make_params_vector_group(params_array, param_labels=None):
+def make_params_vector_group(params_array, param_labels=None, param_label_schema=None):
     dp = create_datapackage()
     kwargs = dict(
         matrix="foo",
@@ -258,6 +258,8 @@ def make_params_vector_group(params_array, param_labels=None):
     )
     if param_labels is not None:
         kwargs["param_labels"] = param_labels
+    if param_label_schema is not None:
+        kwargs["param_label_schema"] = param_label_schema
     dp.add_persistent_vector(**kwargs)
     g = ResourceGroup(package=dp.filter_by_attribute("group", "p"), group_label="p")
     complete_group(g)
@@ -343,6 +345,18 @@ def test_param_labels_returns_dict():
     g = make_params_vector_group(np.array([1.0, 2.0]), param_labels=["alpha", "beta"])
     labels = g.param_labels
     assert labels["values"] == ["alpha", "beta"]
+
+
+def test_param_labels_includes_schema_when_provided():
+    schema = StringLabelSchema(description="a plain string label")
+    g = make_params_vector_group(
+        np.array([1.0, 2.0]),
+        param_labels=["alpha", "beta"],
+        param_label_schema=schema,
+    )
+    labels = g.param_labels
+    assert labels["values"] == ["alpha", "beta"]
+    assert labels["schema"] == schema.to_json_schema()
 
 
 def test_param_labels_raises_if_absent():

--- a/tests/resource_group.py
+++ b/tests/resource_group.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import numpy as np
+import pytest
 from bw_processing import INDICES_DTYPE, create_datapackage, load_datapackage
 from fsspec.implementations.zip import ZipFileSystem
 
@@ -241,3 +242,110 @@ def test_rescale_applied_masked():
     g.calculate()
     # Third element masked; [10, 20] * [0.5, 1.0] = [5, 20]
     assert np.allclose(g.data_current, [5.0, 20.0])
+
+
+# --- params support ---
+
+
+def make_params_vector_group(params_array, param_labels=None):
+    dp = create_datapackage()
+    kwargs = dict(
+        matrix="foo",
+        name="p",
+        indices_array=np.array([(0, 1), (2, 3), (4, 5)], dtype=INDICES_DTYPE),
+        data_array=np.array([10.0, 20.0, 30.0]),
+        params_array=params_array,
+    )
+    if param_labels is not None:
+        kwargs["param_labels"] = param_labels
+    dp.add_persistent_vector(**kwargs)
+    g = ResourceGroup(package=dp.filter_by_attribute("group", "p"), group_label="p")
+    complete_group(g)
+    return g
+
+
+def make_params_array_group(data_array, params_array):
+    dp = create_datapackage(sequential=True)
+    dp.add_persistent_array(
+        matrix="foo",
+        name="p",
+        indices_array=np.array([(0, 1), (2, 3)], dtype=INDICES_DTYPE),
+        data_array=data_array,
+        params_array=params_array,
+    )
+    g = ResourceGroup(package=dp.filter_by_attribute("group", "p"), group_label="p")
+    complete_group(g)
+    return g
+
+
+def test_has_params_false():
+    dp, label = get_vector_group()
+    g = ResourceGroup(package=dp, group_label=label)
+    assert not g.has_params
+
+
+def test_has_params_true_vector():
+    g = make_params_vector_group(np.array([1.0, 2.0]))
+    assert g.has_params
+
+
+def test_params_current_vector():
+    params = np.array([1.5, 2.5, 3.5])
+    g = make_params_vector_group(params)
+    g.calculate()
+    assert np.allclose(g.params_current, params)
+
+
+def test_params_current_vector_fixed_across_iterations():
+    params = np.array([1.5, 2.5])
+    g = make_params_vector_group(params)
+    g.calculate()
+    assert np.allclose(g.params_current, params)
+    next(g.indexer)
+    g.calculate()
+    assert np.allclose(g.params_current, params)
+
+
+def test_params_current_array():
+    data = np.array([[10.0, 11.0, 12.0], [20.0, 21.0, 22.0]])
+    params = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    g = make_params_array_group(data, params)
+    g.calculate()
+    assert np.allclose(g.params_current, [1.0, 4.0])
+    next(g.indexer)
+    g.calculate()
+    assert np.allclose(g.params_current, [2.0, 5.0])
+    next(g.indexer)
+    g.calculate()
+    assert np.allclose(g.params_current, [3.0, 6.0])
+
+
+def test_params_current_raises_if_absent():
+    dp, label = get_vector_group()
+    g = ResourceGroup(package=dp, group_label=label)
+    complete_group(g)
+    g.calculate()
+    with pytest.raises(KeyError):
+        _ = g.params_current
+
+
+def test_has_param_labels_false():
+    g = make_params_vector_group(np.array([1.0, 2.0]))
+    assert not g.has_param_labels
+
+
+def test_has_param_labels_true():
+    g = make_params_vector_group(np.array([1.0, 2.0]), param_labels=["alpha", "beta"])
+    assert g.has_param_labels
+
+
+def test_param_labels_returns_dict():
+    g = make_params_vector_group(np.array([1.0, 2.0]), param_labels=["alpha", "beta"])
+    labels = g.param_labels
+    assert labels["values"] == ["alpha", "beta"]
+
+
+def test_param_labels_raises_if_absent():
+    g = make_params_vector_group(np.array([1.0, 2.0]))
+    with pytest.raises(KeyError):
+        _ = g.param_labels


### PR DESCRIPTION
## Summary

Wires in the `params_array` feature merged in [bw_processing #93](https://github.com/brightway-lca/bw_processing/pull/93) so that `matrix_utils` can read and expose parameter values alongside matrix data — the building block for global sensitivity analysis (Morris, Sobol, etc.).

**`ResourceGroup` — 4 new properties**, following the existing `has_flip` / `has_rescale` guard pattern:

- `has_params` / `has_param_labels` — boolean guards (try/except on the underlying resource)
- `params_current` — for vector resources returns the full 1-D params array (fixed, doesn't vary by indexer); for array resources returns the column at `indexer.index % ncols`, staying in sync with `calculate()`
- `param_labels` — returns the raw dict; always has `"values"`, also has `"schema"` when a label schema was provided at write time

**`MappedMatrix.input_params()`** — returns `{(package, group_label): params_current}` for every group carrying a params array; groups without params are omitted. Keyed by `(package, group_label)` to avoid silent collisions when two packages contribute groups with the same label. For array groups the result advances with `next(mm)`, consistent with all other `input_X` methods.

## Test plan

- [x] `has_params` returns `False` for a group with no params array
- [x] `has_params` returns `True` for a vector group with params
- [x] `params_current` returns the full 1-D array for vector groups
- [x] `params_current` is fixed across indexer iterations for vector groups
- [x] `params_current` returns the correct column per iteration for array groups
- [x] `params_current` raises `KeyError` when no params array is present
- [x] `has_param_labels` / `param_labels` behave correctly (present and absent)
- [x] `param_labels` includes `"schema"` key when a label schema was provided
- [x] `input_params()` returns empty dict when no groups have params
- [x] `input_params()` returns correct values for a vector group
- [x] `input_params()` omits groups without params in a mixed datapackage
- [x] `input_params()` tracks the indexer across Monte Carlo iterations for array groups
- [x] `input_params()` correctly handles duplicate group labels across packages
- [x] All pre-existing tests pass (branch rebased on merged rescale-array changes)