### PR TITLE
Rename scale_array to rescale_array (tracks bw_processing PR #104)

### DIFF
--- a/matrix_utils/mapped_matrix.py
+++ b/matrix_utils/mapped_matrix.py
@@ -347,6 +347,20 @@ class MappedMatrix:
                 arrays.append(grp.apply_masks(grp.get_indices_data()))
         return np.concatenate(arrays)
 
+    def input_rescale_vector(self) -> np.ndarray:
+        """Return rescale factors for each element, aligned with ``input_data_vector``.
+
+        Groups without a rescale array contribute all-ones values.
+        """
+        arrays = []
+        for grp in self.groups:
+            if grp.empty:
+                arrays.append(np.array([]))
+            else:
+                rc = grp.rescale_current
+                arrays.append(rc if rc is not None else np.ones(len(grp.data_current)))
+        return np.hstack(arrays)
+
     def input_flip_vector(self) -> np.ndarray:
         """Return a boolean array indicating which elements were negated before matrix insertion.
 

--- a/matrix_utils/resource_group.py
+++ b/matrix_utils/resource_group.py
@@ -128,9 +128,9 @@ class ResourceGroup:
             return False
 
     @property
-    def has_scale(self) -> bool:
+    def has_rescale(self) -> bool:
         try:
-            self.get_resource_by_suffix("scale")
+            self.get_resource_by_suffix("rescale")
             return True
         except KeyError:
             return False
@@ -153,9 +153,16 @@ class ResourceGroup:
         return self.apply_masks(self.get_resource_by_suffix("flip"))
 
     @property
-    def scale(self):
-        """The scale array, with all masks applied (if necessary)."""
-        return self.apply_masks(self.get_resource_by_suffix("scale"))
+    def rescale(self):
+        """The rescale array, with all masks applied (if necessary)."""
+        return self.apply_masks(self.get_resource_by_suffix("rescale"))
+
+    @property
+    def rescale_current(self) -> Optional[np.ndarray]:
+        """Current rescale values with masks applied, or ``None`` if no rescale array exists."""
+        if self.has_rescale:
+            return self.rescale
+        return None
 
     def get_indices_data(self):
         """The source data for the indices array."""
@@ -326,7 +333,7 @@ class ResourceGroup:
             pass
 
         try:
-            data *= self.scale
+            data *= self.rescale
         except KeyError:
             pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "numpy",
     "scipy>=1.10",
     "pandas",
-    "bw_processing>=1.3",
+    "bw_processing>=1.5",
     "stats_arrays",
 ]
 

--- a/tests/mapped_matrix.py
+++ b/tests/mapped_matrix.py
@@ -1015,7 +1015,7 @@ def test_group_lookup_not_found():
         mm.group("nonexistent")
 
 
-# ── has_flip / has_scale ──────────────────────────────────────────────────────
+# ── has_flip / has_rescale ────────────────────────────────────────────────────
 
 
 def test_has_flip_true():
@@ -1032,24 +1032,24 @@ def test_has_flip_false():
     assert mm.group("vector").has_flip is False
 
 
-def test_has_scale_false():
+def test_has_rescale_false():
     mm = MappedMatrix(
         packages=[basic_mm()], matrix="foo", use_arrays=False, use_distributions=False
     )
-    assert mm.group("vector").has_scale is False
+    assert mm.group("vector").has_rescale is False
 
 
-def test_has_scale_true():
+def test_has_rescale_true():
     dp = bwp.create_datapackage()
     dp.add_persistent_vector(
         matrix="foo",
         name="sv",
         indices_array=np.array([(0, 0), (1, 1)], dtype=bwp.INDICES_DTYPE),
         data_array=np.array([1.0, 2.0]),
-        scale_array=np.array([0.5, 2.0]),
+        rescale_array=np.array([0.5, 2.0]),
     )
     mm = MappedMatrix(packages=[dp], matrix="foo", use_arrays=False, use_distributions=False)
-    assert mm.group("sv").has_scale is True
+    assert mm.group("sv").has_rescale is True
 
 
 # ── n_elements_dropped ─────────────────────────────────────────────────────────────────

--- a/tests/resource_group.py
+++ b/tests/resource_group.py
@@ -148,7 +148,7 @@ def test_row_col_indices_for_mapping_are_contiguous():
     assert np.array_equal(g.unique_col_indices_for_mapping(), np.array([14, 15, 16]))
 
 
-def make_scaled_group(scale_array=None, flip_array=None):
+def make_scaled_group(rescale_array=None, flip_array=None):
     dp = create_datapackage()
     kwargs = dict(
         matrix="foo",
@@ -156,8 +156,8 @@ def make_scaled_group(scale_array=None, flip_array=None):
         indices_array=np.array([(0, 1), (2, 3), (4, 5)], dtype=INDICES_DTYPE),
         data_array=np.array([10.0, 20.0, 30.0]),
     )
-    if scale_array is not None:
-        kwargs["scale_array"] = scale_array
+    if rescale_array is not None:
+        kwargs["rescale_array"] = rescale_array
     if flip_array is not None:
         kwargs["flip_array"] = flip_array
     dp.add_persistent_vector(**kwargs)
@@ -166,41 +166,41 @@ def make_scaled_group(scale_array=None, flip_array=None):
     return g
 
 
-def test_scale_applied_static():
-    scale = np.array([0.5, 1.0, 2.0])
-    g = make_scaled_group(scale_array=scale)
+def test_rescale_applied_static():
+    rescale = np.array([0.5, 1.0, 2.0])
+    g = make_scaled_group(rescale_array=rescale)
     g.calculate()
     assert np.allclose(g.data_current, [5.0, 20.0, 60.0])
 
 
-def test_scale_applied_after_flip():
-    scale = np.array([0.5, 1.0, 2.0])
+def test_rescale_applied_after_flip():
+    rescale = np.array([0.5, 1.0, 2.0])
     flip = np.array([True, False, False])
-    g = make_scaled_group(scale_array=scale, flip_array=flip)
+    g = make_scaled_group(rescale_array=rescale, flip_array=flip)
     g.calculate()
-    # flip negates first element, then scale is applied
+    # flip negates first element, then rescale is applied
     assert np.allclose(g.data_current, [-5.0, 20.0, 60.0])
 
 
-def test_no_scale_unchanged():
+def test_no_rescale_unchanged():
     g = make_scaled_group()
     g.calculate()
     assert np.allclose(g.data_current, [10.0, 20.0, 30.0])
 
 
-def test_scale_applied_array():
+def test_rescale_applied_array():
     dp = create_datapackage(sequential=True)
     # 3 exchanges, 4 columns (Monte Carlo samples)
     data_array = np.array(
         [[10.0, 11.0, 12.0, 13.0], [20.0, 21.0, 22.0, 23.0], [30.0, 31.0, 32.0, 33.0]]
     )
-    scale_array = np.array([0.5, 1.0, 2.0])
+    rescale_array = np.array([0.5, 1.0, 2.0])
     dp.add_persistent_array(
         matrix="foo",
         name="s",
         indices_array=np.array([(0, 1), (2, 3), (4, 5)], dtype=INDICES_DTYPE),
         data_array=data_array,
-        scale_array=scale_array,
+        rescale_array=rescale_array,
     )
     g = ResourceGroup(package=dp.filter_by_attribute("group", "s"), group_label="s")
     complete_group(g)
@@ -215,22 +215,22 @@ def test_scale_applied_array():
     assert np.allclose(g.data_current, [5.5, 21.0, 62.0])
 
 
-def test_scale_applied_vector_override():
-    scale = np.array([0.5, 1.0, 2.0])
-    g = make_scaled_group(scale_array=scale)
+def test_rescale_applied_vector_override():
+    rescale = np.array([0.5, 1.0, 2.0])
+    g = make_scaled_group(rescale_array=rescale)
     g.calculate(vector=np.array([4.0, 5.0, 6.0]))
     assert np.allclose(g.data_current, [2.0, 5.0, 12.0])
 
 
-def test_scale_applied_masked():
-    scale = np.array([0.5, 1.0, 2.0])
+def test_rescale_applied_masked():
+    rescale = np.array([0.5, 1.0, 2.0])
     dp = create_datapackage()
     dp.add_persistent_vector(
         matrix="foo",
         name="s",
         indices_array=np.array([(0, 1), (2, 3), (4, 5)], dtype=INDICES_DTYPE),
         data_array=np.array([10.0, 20.0, 30.0]),
-        scale_array=scale,
+        rescale_array=rescale,
     )
     g = ResourceGroup(package=dp.filter_by_attribute("group", "s"), group_label="s")
     g.add_indexer(SequentialIndexer())


### PR DESCRIPTION
## Summary

- Renames `scale_array` / `scale` / `has_scale` to `rescale_array` / `rescale` / `has_rescale` throughout, tracking the rename in bw_processing PR #104
- Adds `ResourceGroup.rescale_current`: returns the masked rescale array, or `None` if no rescale array exists for this group
- Adds `MappedMatrix.input_rescale_vector()`: stacks rescale factors across all groups (ones for groups without a rescale array), aligned with `input_data_vector()`

## Test plan

- [ ] All 160 tests pass (`pytest`) — including the 5 rescale tests that were previously failing on `main` due to the bw_processing rename
- [ ] Tests cover: static vector, after-flip ordering, no-rescale passthrough, array groups (per-column), vector override, masked elements, `has_rescale` true/false