### PR TITLE
Expose reference (production) exchange arrays on ResourceGroup

### DIFF
--- a/matrix_utils/resource_group.py
+++ b/matrix_utils/resource_group.py
@@ -136,6 +136,14 @@ class ResourceGroup:
             return False
 
     @property
+    def has_reference(self) -> bool:
+        try:
+            self.get_resource_by_suffix("reference")
+            return True
+        except KeyError:
+            return False
+
+    @property
     def has_params(self) -> bool:
         try:
             self.get_resource_by_suffix("params")
@@ -203,6 +211,18 @@ class ResourceGroup:
         """Current rescale values with masks applied, or ``None`` if no rescale array exists."""
         if self.has_rescale:
             return self.rescale
+        return None
+
+    @property
+    def reference(self):
+        """The reference (production) exchange boolean array, with masks applied (if necessary)."""
+        return self.apply_masks(self.get_resource_by_suffix("reference"))
+
+    @property
+    def reference_current(self) -> Optional[np.ndarray]:
+        """Current reference flags with masks applied, or ``None`` if no reference array exists."""
+        if self.has_reference:
+            return self.reference
         return None
 
     def get_indices_data(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "numpy",
     "scipy>=1.10",
     "pandas",
-    "bw_processing>=1.5",
+    "bw_processing>=1.6",
     "stats_arrays",
 ]
 

--- a/tests/mapped_matrix.py
+++ b/tests/mapped_matrix.py
@@ -1154,6 +1154,64 @@ def test_has_rescale_true():
     assert mm.group("sv").has_rescale is True
 
 
+# ── has_reference / reference ──────────────────────────────────────────────────
+
+
+def test_has_reference_false():
+    mm = MappedMatrix(
+        packages=[basic_mm()], matrix="foo", use_arrays=False, use_distributions=False
+    )
+    assert mm.group("vector").has_reference is False
+
+
+def test_has_reference_true():
+    dp = bwp.create_datapackage()
+    dp.add_persistent_vector(
+        matrix="foo",
+        name="sv",
+        indices_array=np.array([(0, 0), (1, 1)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([1.0, 2.0]),
+        reference_array=np.array([True, False], dtype=bool),
+    )
+    mm = MappedMatrix(packages=[dp], matrix="foo", use_arrays=False, use_distributions=False)
+    assert mm.group("sv").has_reference is True
+
+
+def test_reference_values():
+    dp = bwp.create_datapackage()
+    dp.add_persistent_vector(
+        matrix="foo",
+        name="sv",
+        indices_array=np.array([(0, 0), (1, 1)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([1.0, 2.0]),
+        reference_array=np.array([True, False], dtype=bool),
+    )
+    mm = MappedMatrix(packages=[dp], matrix="foo", use_arrays=False, use_distributions=False)
+    group = mm.group("sv")
+    assert group.reference.dtype == bool
+    assert list(group.reference) == [True, False]
+
+
+def test_reference_current_none_when_absent():
+    mm = MappedMatrix(
+        packages=[basic_mm()], matrix="foo", use_arrays=False, use_distributions=False
+    )
+    assert mm.group("vector").reference_current is None
+
+
+def test_reference_current_returns_masked_values():
+    dp = bwp.create_datapackage()
+    dp.add_persistent_vector(
+        matrix="foo",
+        name="sv",
+        indices_array=np.array([(0, 0), (1, 1)], dtype=bwp.INDICES_DTYPE),
+        data_array=np.array([1.0, 2.0]),
+        reference_array=np.array([False, True], dtype=bool),
+    )
+    mm = MappedMatrix(packages=[dp], matrix="foo", use_arrays=False, use_distributions=False)
+    assert list(mm.group("sv").reference_current) == [False, True]
+
+
 # ── n_elements_dropped ─────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

`bw_processing` can now store an optional per-exchange **`reference`** boolean side-resource (`kind="reference"`) marking reference/production exchanges (brightway-lca/bw_processing#108). This PR exposes it on `ResourceGroup`, mirroring the existing `rescale` accessors:

- `has_reference` — whether the group carries a reference array
- `reference` — the array with all masks applied
- `reference_current` — masked array, or `None` when absent

This lets consumers such as `bw_graph_tools` read the modeller-declared reference exchange directly, instead of inferring it from matrix structure (sign/flip/uniqueness heuristics, which cannot disambiguate co-production columns).

## Tests

Added to `tests/mapped_matrix.py`: `has_reference` true/false, `reference` values + dtype, and `reference_current` (present and absent). Full run of `mapped_matrix.py` + `resource_group.py`: **95 passed**.

## Context

Part of a three-repo change (`bw_processing` → `matrix_utils` → `bw_graph_tools`). See cauldron/brightway-api#739 for the problem write-up. Follow-up: `bw_graph_tools` gains an authoritative "heuristic zero" that reads `group.reference` first in `guess_production_exchanges`.

Refs cauldron/brightway-api#739