### PR TITLE
Release 0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.9] - 2026-07-12
+
+* Merge [#45](https://github.com/brightway-lca/matrix_utils/pull/45): Expose reference (production) exchange arrays from [bw_processing #108](https://github.com/brightway-lca/bw_processing/pull/108). New `ResourceGroup` properties `has_reference`, `reference`, and `reference_current`. Requires `bw_processing>=1.6`.
+
 ## [0.8] - 2026-06-04
 
 * Merge [#42](https://github.com/brightway-lca/matrix_utils/pull/42): Rename `scale_array` to `rescale_array`, tracking [bw_processing #104](https://github.com/brightway-lca/bw_processing/pull/104). Adds `ResourceGroup.rescale_current` and `MappedMatrix.input_rescale_vector()`.

--- a/matrix_utils/__init__.py
+++ b/matrix_utils/__init__.py
@@ -11,7 +11,7 @@ __all__ = (
     "SparseMatrixDict",
 )
 
-__version__ = "0.8"
+__version__ = "0.9"
 
 from matrix_utils.array_mapper import ArrayMapper
 from matrix_utils.indexers import CombinatorialIndexer, Proxy, RandomIndexer, SequentialIndexer


### PR DESCRIPTION
Release PR for the reference (production) exchange support merged in #45.

* Bumps `__version__` to `0.9`.
* Adds the `[0.9]` CHANGELOG entry.

#45 is already merged into `main`, so this is a clean version bump + changelog only.

Refs cauldron/brightway-api#739